### PR TITLE
Release 4.0.0 -- update PHP and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 .idea/
 composer.lock
+modules/

--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-{
-  "generalSettings": {
-    "shouldScanRepo": true
-  },
-  "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure"
-  }
-}

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 it-now: clean install test
 
 clean:
-	docker-compose kill
-	docker-compose rm -f
+	docker compose kill
+	docker compose rm -f
 
 install:
-	docker-compose run --rm cli bash -c "composer install"
+	docker compose run --rm cli bash -c "composer install"
 
 update:
-	docker-compose run --rm cli bash -c "composer update"
+	docker compose run --rm cli bash -c "composer update"
 
 test:
-	docker-compose run --rm cli bash -c "cd /data/tests; ../vendor/bin/phpunit ."
+	docker compose run --rm cli bash -c "cd /data/tests; ../vendor/bin/phpunit ."

--- a/README.md
+++ b/README.md
@@ -4,20 +4,32 @@ Various PSR3-compatible logging adapters.
 
 ## Adapter-specific notes
 
-### Psr3ConsoleLogger
-- Since this is ambiguous regarding whether logged messages are affected by
-  PHP's output buffering, we recommend using either `Psr3EchoLogger` or
-  `Psr3StdOutLogger` instead.
-
 ### Psr3EchoLogger
-- This `echo`es out the log messages, allowing the output to be buffered so that
-  it appears at the expected place within the rest of the output (such as in
-  tests).
 
-### Prs3StdOutLogger
-- This writes to stdout, bypassing any output buffering that PHP might be doing.
+A basic PSR-3 compliant logger that merely echoes logs to the console (primarily intended for use in tests).
+
+This `echo`es out the log messages, allowing the output to be buffered so that it appears at the expected place within the rest of the output (such as in tests).
+
+### Psr3FakeLogger
+
+A basic PSR-3 compliant logger that stores log entries in an array. This allows confirmation that logging has occurred using hasLogs and hasSpecificLog methods.
+ 
+### Psr3SamlLogger
+
+A minimalist wrapper library (for SimpleSAML\Logger) to make it PSR-3 compatible.
+
+### Psr3StdOutLogger
+
+A basic PSR-3 compliant logger that writes logs to stdout. This bypasses any output buffering that PHP may be doing.
+
+### Psr3SyslogLogger
+
+A basic PSR-3 compliant logger that sends logs to syslog.
 
 ### Psr3Yii2Logger
-- Make sure your Yii config bootstraps the `log` component. In other words,
-  include something like this in your Yii config:
-  `'bootstrap' => ['log']`
+
+A basic PSR-3 compliant logger that sends logs to Yii2's logging functions. 
+
+NOTE: Yii2 only provides error, warning, info, and trace levels, so the PSR-3 log levels were mapped to those on a best-effort basis.
+
+Make sure your Yii config bootstraps the `log` component. In other words, include something like this in your Yii config: `'bootstrap' => ['log']`

--- a/composer.json
+++ b/composer.json
@@ -11,19 +11,19 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.4 || ^8.0",
-        "psr/log": "^1.0"
+        "php": "^8.1",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "roave/security-advisories": "dev-master",
-        "monolog/monolog": "^1.22",
-        "simplesamlphp/simplesamlphp": "^1.15.2",
+        "monolog/monolog": "^2.0 | ^3.0",
+        "simplesamlphp/simplesamlphp": "^2.0",
         "yiisoft/yii2": "^2.0"
     },
     "suggest": {
-        "monolog/monolog": "^1.22",
-        "simplesamlphp/simplesamlphp": "^1.15.2",
+        "monolog/monolog": "^2.0 | ^3.0",
+        "simplesamlphp/simplesamlphp": "^2.0",
         "yiisoft/yii2": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "config": {
         "allow-plugins": {
             "yiisoft/yii2-composer": true,
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": false
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Various PSR3-compatible logging adapters.",
     "type": "library",
     "license": "MIT",
+    "version": "4.0.0",
     "authors": [
         {
             "name": "Matt Henderson",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
     cli:
         image: silintl/php8:8.1

--- a/src/LoggerBase.php
+++ b/src/LoggerBase.php
@@ -10,26 +10,6 @@ use Psr\Log\AbstractLogger;
 abstract class LoggerBase extends AbstractLogger
 {
     /**
-     * Interpolate context values into the message placeholders.
-     * 
-     * @param string $message The data to be logged.
-     * @param array $context (Optional:) The array of values to insert into the
-     *     corresponding placeholders.
-     * @return string The resulting log message.
-     */
-    protected function interpolate($message, array $context = []): string
-    {
-        if (is_string($message)) {
-            return $this->interpolateString($message, $context);
-        }
-        
-        return $this->interpolateString(
-            var_export($message, true),
-            $context
-        );
-    }
-
-    /**
      * Interpolate context values into the given string.
      * 
      * This is based heavily on the example implementation here:
@@ -40,7 +20,7 @@ abstract class LoggerBase extends AbstractLogger
      *     corresponding placeholders.
      * @return string The resulting string.
      */
-    private function interpolateString(string $message, array $context = []): string
+    protected function interpolate(string $message, array $context = []): string
     {
         // Build a replacement array with braces around the context keys.
         $replace = [];
@@ -52,18 +32,6 @@ abstract class LoggerBase extends AbstractLogger
         }
 
         // Interpolate replacement values into the message.
-        $result = strtr($message, $replace);
-        
-        if (is_string($result)) {
-            return $result;
-        }
-        
-        /* If something went wrong, return the original message (with a
-         * warning).  */
-        return sprintf(
-            '%s (WARNING: Unable to interpolate the context values into the message. %s).',
-            $message,
-            var_export($replace, true)
-        );
+        return strtr($message, $replace);
     }
 }

--- a/src/LoggerBase.php
+++ b/src/LoggerBase.php
@@ -11,22 +11,22 @@ abstract class LoggerBase extends AbstractLogger
 {
     /**
      * Interpolate context values into the given string.
-     * 
+     *
      * This is based heavily on the example implementation here:
      * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#12-message
-     * 
-     * @param string $message The message (potentially with placeholders).
+     *
+     * @param string|\Stringable $message The message (potentially with placeholders).
      * @param array $context (Optional:) The array of values to insert into the
      *     corresponding placeholders.
      * @return string The resulting string.
      */
-    protected function interpolate(string $message, array $context = []): string
+    protected function interpolate(string|\Stringable $message, array $context = []): string
     {
         // Build a replacement array with braces around the context keys.
         $replace = [];
         foreach ($context as $key => $value) {
             // Check that the value can be cast to string.
-            if (!is_array($value) && (!is_object($value) || method_exists($value, '__toString'))) {
+            if (!is_array($value) && (!is_object($value) || $value instanceof \Stringable)) {
                 $replace['{' . $key . '}'] = $value;
             }
         }

--- a/src/Psr3ConsoleLogger.php
+++ b/src/Psr3ConsoleLogger.php
@@ -1,9 +1,0 @@
-<?php
-namespace Sil\Psr3Adapters;
-
-/**
- * A basic PSR-3 compliant logger that merely writes logs to the console.
- */
-class Psr3ConsoleLogger extends Psr3StdOutLogger
-{
-}

--- a/src/Psr3EchoLogger.php
+++ b/src/Psr3EchoLogger.php
@@ -8,13 +8,9 @@ namespace Sil\Psr3Adapters;
 class Psr3EchoLogger extends LoggerBase
 {
     /**
-     * Log a message.
-     *
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
+     * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
     {
         echo sprintf(
             'LOG: [%s] %s',

--- a/src/Psr3FakeLogger.php
+++ b/src/Psr3FakeLogger.php
@@ -9,7 +9,7 @@ namespace Sil\Psr3Adapters;
 class Psr3FakeLogger extends LoggerBase
 {
     /** @var string[] $log */
-    private $log = [];
+    private array $log = [];
 
     /**
      * {@inheritdoc}
@@ -36,7 +36,7 @@ class Psr3FakeLogger extends LoggerBase
      * @param bool $strict
      * @return bool
      */
-    public function hasSpecificLog(string $needle, $strict = false): bool
+    public function hasSpecificLog(string $needle, bool $strict = false): bool
     {
         $strictMatch = false;
         $looseMatch = false;

--- a/src/Psr3FakeLogger.php
+++ b/src/Psr3FakeLogger.php
@@ -12,13 +12,9 @@ class Psr3FakeLogger extends LoggerBase
     private $log = [];
 
     /**
-     * Log a message.
-     *
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
+     * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
     {
         $this->log[] = sprintf(
             'LOG: [%s] %s',

--- a/src/Psr3SamlLogger.php
+++ b/src/Psr3SamlLogger.php
@@ -12,15 +12,9 @@ use SimpleSAML\Logger;
 class Psr3SamlLogger extends LoggerBase
 {
     /**
-     * Log a message.
-     *
-     * @param mixed $level One of the \Psr\Log\LogLevel::* constants.
-     * @param string $message The message to log, possibly with {placeholder}s.
-     * @param array $context An array of placeholder => value entries to insert
-     *     into the message.
-     * @return void
+     * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
     {
         $messageWithContext = $this->interpolate($message, $context);
         switch ($level) {

--- a/src/Psr3StdOutLogger.php
+++ b/src/Psr3StdOutLogger.php
@@ -9,13 +9,9 @@ namespace Sil\Psr3Adapters;
 class Psr3StdOutLogger extends LoggerBase
 {
     /**
-     * Log a message.
-     *
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
+     * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
     {
         $this->writeToStdOut(
             sprintf(

--- a/src/Psr3StdOutLogger.php
+++ b/src/Psr3StdOutLogger.php
@@ -22,7 +22,7 @@ class Psr3StdOutLogger extends LoggerBase
         );
     }
 
-    private function writeToStdOut($message)
+    private function writeToStdOut(string $message): void
     {
         $fileHandle = fopen('php://stdout', 'w+');
         if ($fileHandle === false) {

--- a/src/Psr3SyslogLogger.php
+++ b/src/Psr3SyslogLogger.php
@@ -10,7 +10,7 @@ use Monolog\Logger;
  */
 class Psr3SyslogLogger extends LoggerBase
 {
-    private $logger;
+    private Logger $logger;
     
     public function __construct($name = 'name', $ident = 'ident')
     {

--- a/src/Psr3SyslogLogger.php
+++ b/src/Psr3SyslogLogger.php
@@ -2,6 +2,7 @@
 namespace Sil\Psr3Adapters;
 
 use Monolog\Handler\SyslogHandler;
+use Monolog\Level;
 use Monolog\Logger;
 
 /**
@@ -17,7 +18,7 @@ class Psr3SyslogLogger extends LoggerBase
         $this->logger->pushHandler(new SyslogHandler(
             $ident,
             LOG_USER,
-            Logger::WARNING
+            Level::Warning
         ));
     }
 

--- a/src/Psr3SyslogLogger.php
+++ b/src/Psr3SyslogLogger.php
@@ -20,16 +20,11 @@ class Psr3SyslogLogger extends LoggerBase
             Logger::WARNING
         ));
     }
-    
+
     /**
-     * Log a message.
-     *
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
-     * @return void
+     * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
     {
         $this->logger->log($level, $message, $context);
     }

--- a/src/Psr3Yii2Logger.php
+++ b/src/Psr3Yii2Logger.php
@@ -14,21 +14,12 @@ use Yii;
 class Psr3Yii2Logger extends LoggerBase
 {
     /**
-     * Log a message.
-     *
-     * @param mixed $level One of the \Psr\Log\LogLevel::* constants.
-     * @param string|array $message The message to log, possibly with {placeholder}s.
-     * @param array $context An array of placeholder => value entries to insert
-     *     into the message.
-     * @return void
+     * {@inheritdoc}
      */
-    public function log($level, $message, array $context = [])
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
     {
-        if (is_array($message)) {
-            $messageToLog = array_merge($message, $context);
-        } else {
-            $messageToLog = $this->interpolate($message, $context);
-        }
+        $messageToLog = $this->interpolate($message, $context);
+
         switch ($level) {
             case PsrLogLevel::EMERGENCY:
             case PsrLogLevel::ALERT:

--- a/tests/Psr3EveryLoggerTest.php
+++ b/tests/Psr3EveryLoggerTest.php
@@ -59,10 +59,7 @@ class Psr3EveryLoggerTest extends TestCase
         $this->checkSpecificLogger(new Psr3FakeLogger());
     }
 
-    /**
-     * @param LoggerInterface $logger
-     */
-    private function checkSpecificLogger($logger)
+    private function checkSpecificLogger(LoggerInterface $logger): void
     {
         self::assertIsObject(
             $logger,

--- a/tests/Psr3EveryLoggerTest.php
+++ b/tests/Psr3EveryLoggerTest.php
@@ -4,7 +4,6 @@ namespace Sil\Psr3Adapters\tests;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel as PsrLogLevel;
-use Sil\Psr3Adapters\Psr3ConsoleLogger;
 use Sil\Psr3Adapters\Psr3EchoLogger;
 use Sil\Psr3Adapters\Psr3FakeLogger;
 use Sil\Psr3Adapters\Psr3SamlLogger;
@@ -28,11 +27,6 @@ class Psr3EveryLoggerTest extends TestCase
     public function testLogKnownLogLevelYii2()
     {
         $this->checkSpecificLogger(new Psr3Yii2Logger());
-    }
-
-    public function testLogKnownLogLevelConsole()
-    {
-        $this->checkSpecificLogger(new Psr3ConsoleLogger());
     }
 
     public function testLogKnownLogLevelEcho()

--- a/tests/Psr3EveryLoggerTest.php
+++ b/tests/Psr3EveryLoggerTest.php
@@ -52,8 +52,12 @@ class Psr3EveryLoggerTest extends TestCase
 
     public function testLogKnownLogLevelSaml()
     {
-        putenv('SIMPLESAMLPHP_CONFIG_DIR=../vendor/simplesamlphp/simplesamlphp/config-templates/');
+        putenv('SIMPLESAMLPHP_CONFIG_DIR=.');
+        copy('../vendor/simplesamlphp/simplesamlphp/config/config.php.dist', './config.php');
+        copy('../vendor/simplesamlphp/simplesamlphp/config/authsources.php.dist', './authsources.php');
         $this->checkSpecificLogger(new Psr3SamlLogger());
+        unlink('./authsources.php');
+        unlink('./config.php');
     }
 
     public function testLogKnownLogLevelFake()
@@ -114,12 +118,12 @@ class Psr3EveryLoggerTest extends TestCase
     public function testArrayYii2()
     {
         $logger = new Psr3Yii2Logger();
-        $message = [
+        $message = json_encode([
             'from' => ['log@example.com'],
             'to' => ['developer1@example.com', 'developer2@example.com'],
             'subject' => 'Log message',
             'formattedMessage' => ['Do not attempt to follow this example.'],
-        ];
+        ]);
         $logger->log(PsrLogLevel::ERROR, $message);
         self::assertTrue(true, 'No errors means it likely worked.');
     }

--- a/tests/Psr3FakeLoggerTest.php
+++ b/tests/Psr3FakeLoggerTest.php
@@ -3,6 +3,7 @@ namespace Sil\Psr3Adapters\tests;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel as PsrLogLevel;
 use Sil\Psr3Adapters\Psr3FakeLogger;
 
 class Psr3FakeLoggerTest extends TestCase
@@ -28,5 +29,14 @@ class Psr3FakeLoggerTest extends TestCase
 
         $hasSpecificLog = $psr3FakeLogger->hasSpecificLog('LOG: [warning] Specific message', true);
         Assert::assertTrue($hasSpecificLog, 'Missing expected specific log entry (tight)');
+    }
+
+    public function testObject()
+    {
+        $logger = new Psr3FakeLogger();
+        $message = new StringableObject('{key}');
+        $value = new StringableObject('needle');
+        $logger->log(PsrLogLevel::ERROR, $message, ['key' => $value]);
+        self::assertTrue($logger->hasSpecificLog('needle'));
     }
 }

--- a/tests/StringableObject.php
+++ b/tests/StringableObject.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sil\Psr3Adapters\tests;
+
+class StringableObject implements \Stringable
+{
+    private string $a;
+    private string $b;
+
+    public function __construct(string $a = '', string $b = '')
+    {
+        $this->a = $a;
+        $this->b = $b;
+    }
+
+    public function __toString(): string
+    {
+        return $this->a . $this->b;
+    }
+}


### PR DESCRIPTION
### Changed (breaking)
- Require PHP 8.1 and psr/log 3
- Require SimpleSAMLphp 2.x for `Psr3SamlLogger`
- Added type hints

### Changed (non-breaking)
- Use updated docker compose 
- Simplified `LoggerBase` based on stricter types
- Don't run composer-module-installer 

### Fixed
- Updated README to include all loggers

### Removed
- Removed `Psr3ConsoleLogger`. Use `Psr3EchoLogger` or `Psr3StdOutLogger` instead.
- Removed unused .whitespace file
- Remove use of deprecated `Logger::WARNING`
